### PR TITLE
add build steps to README, simplify gulpfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules
+.vagrant

--- a/README.md
+++ b/README.md
@@ -62,5 +62,15 @@ In order to keep things simple, there will be no concept of branching in this re
 
 All releases (major and minor) of the demo repo should be made available in .zip and .tar.gz formats.
 
+### Creating dists
+
 These .zip and .tar.gz distributions can be generated using Gulp.
 
+**Prerequisites**
+
+- [node](http://nodejs.org/)
+
+**Instructions**
+
+1. npm install
+2. gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,8 +7,8 @@ var gulp = require('gulp'),
 
 var version = package.version;
 
-gulp.task('stage', ['clean-stage'], function(cb) {
-	return gulp.src(['**/*', '!node_modules/**'])
+gulp.task('stage', ['clean'], function(cb) {
+	return gulp.src(['**/*', '!node_modules/**', '!node_modules'])
 		.pipe(gulp.dest('stage/elasticsearch-demo-' + version));
 });
 
@@ -26,11 +26,7 @@ gulp.task('tar', [], function() {
 });
 
 gulp.task('clean', function(cb) {
-    del(['dist'], cb)
-});
-
-gulp.task('clean-stage', function(cb) {
-    del(['stage'], cb)
+    del(['dist', 'stage'], cb)
 });
 
 gulp.task('default', ['clean', 'stage'], function() {


### PR DESCRIPTION
Add Gulp build script to generate .zip and .tar.gz files.